### PR TITLE
Update VM environment & Ubuntu version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OPTIONS:
   -m mirror   Ubuntu mirror address - default: Nuxeo internal mirror  
 
 
-If -d is not specified, the distribution will be downloaded from a maven repository.
+If -d is not specified, the distribution will be downloaded.
 
 
 ## Requirements:

--- a/templates/nuxeovm.ovf
+++ b/templates/nuxeovm.ovf
@@ -30,7 +30,7 @@
             including, for example, alpha or beta designations
             and other release criteria.
         -->
-      <Version>9.2.0.0</Version>
+      <Version>@@VERSION@@.0.0</Version>
       <FullVersion>@@VERSION@@</FullVersion>
       <ProductUrl>http://www.nuxeo.com/products</ProductUrl>
       <VendorUrl>http://www.nuxeo.com/</VendorUrl>
@@ -67,7 +67,7 @@
     </AnnotationSection>
     <OperatingSystemSection ovf:id="94" ovf:version="" vmw:osType="ubuntuGuest">
       <Info>Guest Operating System</Info>
-      <Description>Ubuntu 14.04.1</Description>
+      <Description>Ubuntu 16.04.5</Description>
     </OperatingSystemSection>
     <VirtualHardwareSection ovf:transport="com.vmware.guestInfo" ovf:required="false">
       <Info>Virtual Hardware Requirements</Info>

--- a/vmfiles/firstboot.sh
+++ b/vmfiles/firstboot.sh
@@ -21,7 +21,7 @@ nuxeo:$nxpass
 EOF
 
 cat << 'EOF' > /etc/issue
-Ubuntu 14.04 LTS \n \l
+Ubuntu 16.04.5 LTS \n \l
 EOF
 
 cat << EOF >> /etc/issue

--- a/vmfiles/nuxeo.init
+++ b/vmfiles/nuxeo.init
@@ -11,11 +11,7 @@
 
 DESC="Nuxeo"
 
-NUXEO_USER=nuxeo
-NUXEOCTL="/var/lib/nuxeo/server/bin/nuxeoctl"
-NUXEO_CONF="/etc/nuxeo/nuxeo.conf"
-export NUXEO_CONF
-
+. /etc/profile.d/nuxeo_env.sh
 . /lib/init/vars.sh
 . /lib/lsb/init-functions
 

--- a/vmfiles/nuxeo_env.sh
+++ b/vmfiles/nuxeo_env.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+NUXEO_HOME="/var/lib/nuxeo/server"
+NUXEO_CONF="/etc/nuxeo/nuxeo.conf"
+NUXEO_USER="nuxeo"
+
+NUXEOCTL="${NUXEO_HOME}/bin/nuxeoctl"
+
+PATH="${PATH}:${NUXEO_HOME}/bin"
+
+export NUXEO_HOME NUXEO_CONF NUXEO_USER NUXEOCTL PATH

--- a/vmscripts/base.sh
+++ b/vmscripts/base.sh
@@ -17,6 +17,8 @@ DEBIAN_FRONTEND=noninteractive apt-get -q -y install ffmpeg-nuxeo ccextractor-nu
 
 mv /tmp/vmfiles/nuxeo.init /etc/init.d/nuxeo
 chmod +x /etc/init.d/nuxeo
+mv /tmp/vmfiles/nuxeo_env.sh /etc/profile.d/nuxeo_env.sh
+chmod +rx /etc/profile.d/nuxeo_env.sh
 mv /tmp/vmfiles/nuxeo.apache2 /etc/apache2/sites-available/nuxeo.conf
 mv /tmp/vmfiles/showaddress /sbin/showaddress
 chmod +x /sbin/showaddress


### PR DESCRIPTION
Set VM environment in /etc/profile.d for Nuxeo, add $HOME/bin to $PATH
Update version numbers

This fixes several minor annoyances when using the VM.  nuxeoctl will now work correctly.