### PR TITLE
NXBT-2478: Use 'command' instead of hash

### DIFF
--- a/build-vm.sh
+++ b/build-vm.sh
@@ -111,44 +111,44 @@ fi
 # Check requirements
 reqsok=true
 
-hash mvn &>/dev/null
+command -v mvn &>/dev/null
 CMDFOUND=$?
 if [[ -z "$distrib" && 0 -ne "$CMDFOUND" ]]; then
     reqsok=false
     echo "Missing: mvn (package maven)"
 fi
-hash wget &>/dev/null
+command -v wget &>/dev/null
 CMDFOUND=$?
 if [[ $distrib == *"://"* && 0 -ne "$CMDFOUND" ]]; then
     reqsok=false
     echo "Missing: wget (package wget)"
 fi
-hash packer &>/dev/null
+command -v packer &>/dev/null
 CMDFOUND=$?
 if [ 0 -ne "$CMDFOUND" ]; then
     reqsok=false
     echo "Missing: packer (http://packer.io/)"
 fi
-hash qemu-img &>/dev/null
+command -v qemu-img &>/dev/null
 CMDFOUND=$?
 if [ 0 -ne "$CMDFOUND" ]; then
     reqsok=false
     echo "Missing: qemu-img (package qemu-utils)"
 fi
-hash zip &>/dev/null
+command -v zip &>/dev/null
 CMDFOUND=$?
 if [ 0 -ne "$CMDFOUND" ]; then
     reqsok=false
     echo "Missing: zip (package zip)"
 fi
 if [ "x$builder" == "xqemu" ]; then
-    hash kvm &>/dev/null
+    command -v kvm &>/dev/null
     CMDFOUND=$?
     if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false
         echo "Missing: kvm (package qemu-kvm)"
     fi
-    hash VBoxManage &>/dev/null
+    command -v VBoxManage &>/dev/null
     CMDFOUND=$?
     if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false
@@ -159,7 +159,7 @@ if [ "x$builder" == "xqemu" ]; then
     fi
 fi
 if [ "x$builder" == "xvmware" ]; then
-    hash vmrun &>/dev/null
+    command -v vmrun &>/dev/null
     CMDFOUND=$?
     if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false
@@ -167,7 +167,7 @@ if [ "x$builder" == "xvmware" ]; then
     fi
 fi
 if [ "x$builder" == "xvirtualbox" ]; then
-    hash VBoxManage &>/dev/null
+    command -v VBoxManage &>/dev/null
     CMDFOUND=$?
     if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false

--- a/build-vm.sh
+++ b/build-vm.sh
@@ -111,36 +111,65 @@ fi
 # Check requirements
 reqsok=true
 
-haspacker=$(which packer)
-if [ -z "$haspacker" ]; then
+hash mvn &>/dev/null
+CMDFOUND=$?
+if [[ -z "$distrib" && 0 -ne "$CMDFOUND" ]]; then
+    reqsok=false
+    echo "Missing: mvn (package maven)"
+fi
+hash wget &>/dev/null
+CMDFOUND=$?
+if [[ $distrib == *"://"* && 0 -ne "$CMDFOUND" ]]; then
+    reqsok=false
+    echo "Missing: wget (package wget)"
+fi
+hash packer &>/dev/null
+CMDFOUND=$?
+if [ 0 -ne "$CMDFOUND" ]; then
     reqsok=false
     echo "Missing: packer (http://packer.io/)"
 fi
-hasqemuimg=$(which qemu-img)
-if [ -z "$hasqemuimg" ]; then
+hash qemu-img &>/dev/null
+CMDFOUND=$?
+if [ 0 -ne "$CMDFOUND" ]; then
     reqsok=false
     echo "Missing: qemu-img (package qemu-utils)"
 fi
+hash zip &>/dev/null
+CMDFOUND=$?
+if [ 0 -ne "$CMDFOUND" ]; then
+    reqsok=false
+    echo "Missing: zip (package zip)"
+fi
 if [ "x$builder" == "xqemu" ]; then
-    haskvm=$(which kvm)
-    if [ -z "$haskvm" ]; then
+    hash kvm &>/dev/null
+    CMDFOUND=$?
+    if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false
         echo "Missing: kvm (package qemu-kvm)"
+    fi
+    hash VBoxManage &>/dev/null
+    CMDFOUND=$?
+    if [ 0 -ne "$CMDFOUND" ]; then
+        reqsok=false
+        echo "Missing: VBoxManage (package virtualbox)"
     fi
     if [[ ! -w /dev/kvm ]]; then
        echo "Warning: Unable to write to /dev/kvm.  Build may fail."
     fi
 fi
 if [ "x$builder" == "xvmware" ]; then
-    hasvmrun=$(which vmrun)
-    if [ -z "$hasvmrun" ]; then
+    hash vmrun &>/dev/null
+    CMDFOUND=$?
+    if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false
         echo "Missing: vmrun (VMware Player & VIX)"
     fi
 fi
 if [ "x$builder" == "xvirtualbox" ]; then
-    hasvbox=$(which VBoxManage)
-    if [ -z "$hasvbox" ]; then
+    hash VBoxManage &>/dev/null
+    CMDFOUND=$?
+    if [ 0 -ne "$CMDFOUND" ]; then
         reqsok=false
         echo "Missing: VBoxManage (package virtualbox)"
     fi


### PR DESCRIPTION
Amend commit 7d12fc8 to use 'command -v' built-in instead of 'hash' check.